### PR TITLE
feat: symlink for images folder under post directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ dist
 # site
 public/atom*
 public/sitemap*
+
+# editor
+.obsidian/

--- a/lib/ssg.js
+++ b/lib/ssg.js
@@ -22,16 +22,18 @@ export const getMdPostsData = mdDirectory => {
     mdDirectory = defaultMarkdownDirectory;
   }
   const mdPostNames = fs.readdirSync(mdDirectory);
-  const mdPostsData = mdPostNames.map(mdPostName => {
-    const id = mdPostName.replace(/\.md$/, "");
-    const fullPath = path.join(mdDirectory, mdPostName);
-    const mdContent = fs.readFileSync(fullPath, "utf8");
-    const matterResult = matter(mdContent);
-    return {
-      id,
-      ...matterResult.data,
-    };
-  });
+  const mdPostsData = mdPostNames
+    .filter(fileName => fileName.includes(".md"))
+    .map(mdPostName => {
+      const id = mdPostName.replace(/\.md$/, "");
+      const fullPath = path.join(mdDirectory, mdPostName);
+      const mdContent = fs.readFileSync(fullPath, "utf8");
+      const matterResult = matter(mdContent);
+      return {
+        id,
+        ...matterResult.data,
+      };
+    });
   return mdPostsData.sort(sortByDate);
 };
 

--- a/posts/images
+++ b/posts/images
@@ -1,0 +1,1 @@
+../public/images


### PR DESCRIPTION
#58 that solution looks unreachable since the next.js building failure:

```
Collected static files (public/, static/, .next/static): 8.288ms
Error: ENOENT: no such file or directory, mkdir '/vercel/output/static/images'
```
We switch the symlink direction.