### PR TITLE
feat: polymarket

### DIFF
--- a/components/blog.js
+++ b/components/blog.js
@@ -130,18 +130,16 @@ const Blog = props => {
         </div>
         <ArticleImageZoom containerRef={articleRef} contentKey={`${id}:${locale}`} />
       </article>
-      {!props.noMeta && (
-        <>
-          <div className="tags mt-10">
-            <div>
-              {tags && tags.split(",").map(each => <Tag tag={each} key={each} locale={locale} />)}
-            </div>
+      <>
+        <div className="tags mt-10">
+          <div>
+            {tags && tags.split(",").map(each => <Tag tag={each} key={each} locale={locale} />)}
           </div>
-          <hr />
-          <ArticleActions translations={translations} />
-          <ArticleSocial translations={translations} noReply={props.noReply} />
-        </>
-      )}
+        </div>
+        <hr />
+        <ArticleActions translations={translations} />
+        <ArticleSocial translations={translations} noReply={props.noReply} />
+      </>
     </Layout>
   );
 };

--- a/components/polymarket-probability-board.js
+++ b/components/polymarket-probability-board.js
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
-const CHART_HEIGHT = 420;
+const CHART_HEIGHT = 400;
 const PLOT_TOP = 92;
 const PLOT_BOTTOM = 56;
-const RIGHT_GUTTER = 24;
+const RIGHT_GUTTER = 10;
 const LEFT_GUTTER = 10;
 const MAX_VISIBLE_SERIES = 4;
 const HOVER_LABEL_GAP = 8;
@@ -157,9 +157,7 @@ const densifyHistory = history => {
     const segmentRatio =
       (timestamp - left.timestamp) / Math.max(right.timestamp - left.timestamp, 1);
     const linearPrice = left.price + (right.price - left.price) * segmentRatio;
-    const wave = Math.sin(ratio * Math.PI * Math.max(history.length - 1, 1)) * 0.35;
-    const amplitude = Math.max(Math.abs(right.price - left.price), 0.6);
-    const price = Math.max(0, Math.min(100, linearPrice + wave * amplitude));
+    const price = Math.max(0, Math.min(100, linearPrice));
 
     points.push({
       timestamp,
@@ -470,7 +468,7 @@ function EventEmbedFigure({ group }) {
   return (
     <figure
       ref={containerRef}
-      className="relative m-0 w-full max-w-[920px] overflow-hidden border border-[var(--pm-border)] bg-[var(--pm-bg)] p-5 text-[var(--pm-title)] [--pm-axis:#94A3B8] [--pm-bg:#FFFFFF] [--pm-border:#E2E8F0] [--pm-hover-line:#CBD5E1] [--pm-hover-line-idle:#E2E8F0] [--pm-muted:#64748B] [--pm-muted-line:#94A3B8] [--pm-shadow-path:rgba(15,23,42,0.12)] [--pm-title:#0F172A] [--pm-tooltip-bg:#FFFFFF] [--pm-tooltip-border:#CBD5E1] [--pm-tooltip-text:#0F172A] dark:[--pm-axis:#334253] dark:[--pm-bg:#18181B] dark:[--pm-border:#151A21] dark:[--pm-hover-line:#334155] dark:[--pm-hover-line-idle:#151A20] dark:[--pm-muted:#91A0B4] dark:[--pm-muted-line:#48515D] dark:[--pm-shadow-path:rgba(0,0,0,0.18)] dark:[--pm-title:#F3F5F7] dark:[--pm-tooltip-bg:#0A0D11] dark:[--pm-tooltip-border:#293240] dark:[--pm-tooltip-text:#F3F5F7]"
+      className="relative m-0 w-full max-w-220 overflow-hidden border border-(--pm-border) bg-(--pm-bg) px-2 py-0 text-[var(--pm-title)] [--pm-axis:#94A3B8] [--pm-bg:#FFFFFF] [--pm-border:#E2E8F0] [--pm-hover-line:#CBD5E1] [--pm-hover-line-idle:#E2E8F0] [--pm-muted:#64748B] [--pm-muted-line:#94A3B8] [--pm-shadow-path:rgba(15,23,42,0.12)] [--pm-title:#0F172A] [--pm-tooltip-bg:#FFFFFF] [--pm-tooltip-border:#CBD5E1] [--pm-tooltip-text:#0F172A] dark:[--pm-axis:#334253] dark:[--pm-bg:#18181B] dark:[--pm-border:#151A21] dark:[--pm-hover-line:#334155] dark:[--pm-hover-line-idle:#151A20] dark:[--pm-muted:#91A0B4] dark:[--pm-muted-line:#48515D] dark:[--pm-shadow-path:rgba(0,0,0,0.18)] dark:[--pm-title:#F3F5F7] dark:[--pm-tooltip-bg:#0A0D11] dark:[--pm-tooltip-border:#293240] dark:[--pm-tooltip-text:#F3F5F7]"
       aria-label={`prediction market: ${group.title}`}
       itemScope
       itemType="https://schema.org/WebPage"
@@ -497,8 +495,9 @@ function EventEmbedFigure({ group }) {
             x={LEFT_GUTTER}
             y={CHART_TITLE_Y}
             fill="var(--pm-title)"
-            fontSize="26"
-            fontWeight="700"
+            fontSize="22"
+            fontWeight="600"
+            className="text-balance"
           >
             <title>{group.title}</title>
             {chartTitle}
@@ -523,14 +522,16 @@ function EventEmbedFigure({ group }) {
             </div>
           </foreignObject>
 
-          <line
-            x1={hoverX ?? geometry.plotEndX}
-            x2={hoverX ?? geometry.plotEndX}
-            y1={PLOT_TOP - 6}
-            y2={CHART_HEIGHT - PLOT_BOTTOM + 4}
-            stroke={hoverX === null ? "var(--pm-hover-line-idle)" : "var(--pm-hover-line)"}
-            strokeWidth="1.5"
-          />
+          {hoverX !== null && (
+            <line
+              x1={hoverX}
+              x2={hoverX}
+              y1={PLOT_TOP - 6}
+              y2={CHART_HEIGHT - PLOT_BOTTOM + 4}
+              stroke="var(--pm-hover-line)"
+              strokeWidth="1.5"
+            />
+          )}
 
           {visibleSeries.map(item => {
             const split =

--- a/components/polymarket-probability-board.js
+++ b/components/polymarket-probability-board.js
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 const CHART_HEIGHT = 400;
 const PLOT_TOP = 92;
 const PLOT_BOTTOM = 56;
-const RIGHT_GUTTER = 10;
+const RIGHT_GUTTER = 14;
 const LEFT_GUTTER = 10;
 const MAX_VISIBLE_SERIES = 4;
 const HOVER_LABEL_GAP = 8;
@@ -468,7 +468,7 @@ function EventEmbedFigure({ group }) {
   return (
     <figure
       ref={containerRef}
-      className="relative m-0 w-full max-w-220 overflow-hidden border border-(--pm-border) bg-(--pm-bg) px-2 py-0 text-[var(--pm-title)] [--pm-axis:#94A3B8] [--pm-bg:#FFFFFF] [--pm-border:#E2E8F0] [--pm-hover-line:#CBD5E1] [--pm-hover-line-idle:#E2E8F0] [--pm-muted:#64748B] [--pm-muted-line:#94A3B8] [--pm-shadow-path:rgba(15,23,42,0.12)] [--pm-title:#0F172A] [--pm-tooltip-bg:#FFFFFF] [--pm-tooltip-border:#CBD5E1] [--pm-tooltip-text:#0F172A] dark:[--pm-axis:#334253] dark:[--pm-bg:#18181B] dark:[--pm-border:#151A21] dark:[--pm-hover-line:#334155] dark:[--pm-hover-line-idle:#151A20] dark:[--pm-muted:#91A0B4] dark:[--pm-muted-line:#48515D] dark:[--pm-shadow-path:rgba(0,0,0,0.18)] dark:[--pm-title:#F3F5F7] dark:[--pm-tooltip-bg:#0A0D11] dark:[--pm-tooltip-border:#293240] dark:[--pm-tooltip-text:#F3F5F7]"
+      className="relative m-0 w-full max-w-220 overflow-hidden bg-(--pm-bg) px-2 py-0 text-(--pm-title) [--pm-axis:#94A3B8] [--pm-bg:#FFFFFF] [--pm-border:#E2E8F0] [--pm-hover-line:#CBD5E1] [--pm-hover-line-idle:#E2E8F0] [--pm-muted:#64748B] [--pm-muted-line:#94A3B8] [--pm-shadow-path:rgba(15,23,42,0.12)] [--pm-title:#0F172A] [--pm-tooltip-bg:#FFFFFF] [--pm-tooltip-border:#CBD5E1] [--pm-tooltip-text:#0F172A] dark:[--pm-axis:#334253] dark:[--pm-bg:#18181B] dark:[--pm-border:#151A21] dark:[--pm-hover-line:#334155] dark:[--pm-hover-line-idle:#151A20] dark:[--pm-muted:#91A0B4] dark:[--pm-muted-line:#48515D] dark:[--pm-shadow-path:rgba(0,0,0,0.18)] dark:[--pm-title:#F3F5F7] dark:[--pm-tooltip-bg:#0A0D11] dark:[--pm-tooltip-border:#293240] dark:[--pm-tooltip-text:#F3F5F7]"
       aria-label={`prediction market: ${group.title}`}
       itemScope
       itemType="https://schema.org/WebPage"
@@ -482,7 +482,7 @@ function EventEmbedFigure({ group }) {
       {geometry ? (
         <svg
           viewBox={`0 0 ${Math.max(width, 320)} ${CHART_HEIGHT}`}
-          className="block h-[420px] w-full"
+          className="block h-105 w-full"
           onMouseLeave={() => setHoverX(null)}
           onMouseMove={event => {
             const rect = event.currentTarget.getBoundingClientRect();
@@ -504,7 +504,7 @@ function EventEmbedFigure({ group }) {
           </text>
 
           <foreignObject x={LEFT_GUTTER} y={CHART_LEGEND_Y} width={geometry.plotWidth} height="34">
-            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[13px] leading-none text-[var(--pm-muted)]">
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[13px] leading-none text-(--pm-muted)">
               {visibleSeries.map(item => (
                 <div key={item.id} className="flex items-center gap-2">
                   <span
@@ -512,8 +512,8 @@ function EventEmbedFigure({ group }) {
                     style={{ backgroundColor: item.color }}
                   />
                   <span>
-                    {item.shortLabel}{" "}
-                    <span className="font-semibold text-[var(--pm-title)]">
+                    {item.shortLabel}
+                    <span className="font-semibold text-(--pm-title) pl-1">
                       {formatPercent(item.yesPercent)}
                     </span>
                   </span>
@@ -636,8 +636,7 @@ function EventEmbedFigure({ group }) {
                         x={labelX + HOVER_LABEL_PADDING_X + 8}
                         y={item.labelY + 1}
                         fill="var(--pm-tooltip-text)"
-                        fontSize="15"
-                        fontWeight="600"
+                        fontSize="13"
                         dominantBaseline="middle"
                       >
                         <title>{item.label}</title>
@@ -647,7 +646,7 @@ function EventEmbedFigure({ group }) {
                         x={labelX + labelWidth - HOVER_LABEL_PADDING_X}
                         y={item.labelY + 1}
                         fill="var(--pm-muted)"
-                        fontSize="15"
+                        fontSize="13"
                         fontWeight="600"
                         dominantBaseline="middle"
                         textAnchor="end"
@@ -665,7 +664,7 @@ function EventEmbedFigure({ group }) {
               x={Math.max(width, 320) - RIGHT_GUTTER}
               y={PLOT_TOP - 16}
               fill="var(--pm-muted)"
-              fontSize="14"
+              fontSize="10"
               textAnchor="end"
             >
               {hoverLabel}
@@ -686,7 +685,7 @@ function EventEmbedFigure({ group }) {
           ))}
         </svg>
       ) : (
-        <div className="flex h-[420px] items-center justify-center text-sm text-[var(--pm-muted)]">
+        <div className="flex h-105 items-center justify-center text-sm text-(--pm-muted)">
           暂无走势图数据
         </div>
       )}

--- a/components/polymarket-probability-board.js
+++ b/components/polymarket-probability-board.js
@@ -1,0 +1,722 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+const CHART_HEIGHT = 420;
+const PLOT_TOP = 92;
+const PLOT_BOTTOM = 56;
+const RIGHT_GUTTER = 24;
+const LEFT_GUTTER = 10;
+const MAX_VISIBLE_SERIES = 4;
+const HOVER_LABEL_GAP = 8;
+const HOVER_LABEL_HEIGHT = 34;
+const HOVER_LABEL_MAX_WIDTH = 260;
+const HOVER_LABEL_PADDING_X = 14;
+const CHART_TITLE_RESERVED_WIDTH = 112;
+const CHART_TITLE_Y = PLOT_TOP - 60;
+const CHART_LEGEND_Y = PLOT_TOP - 42;
+const COLORS = ["#8BC0FF", "#2F93FF", "#FFC61A", "#FF8A1F", "#6EE7B7", "#C084FC", "#FB7185"];
+const MIN_RENDER_POINTS = 36;
+
+const formatPercent = value => {
+  if (!Number.isFinite(value)) {
+    return "--";
+  }
+
+  if (value >= 10) {
+    return `${Math.round(value)}%`;
+  }
+
+  const rounded = Math.round(value * 10) / 10;
+  return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)}%`;
+};
+
+const formatTimeLabel = timestamp =>
+  new Date(timestamp).toLocaleDateString("zh-CN", {
+    month: "numeric",
+    day: "numeric",
+  });
+
+const clampPercent = value => Math.min(100, Math.max(0, value));
+
+const buildPriceDomain = points => {
+  const prices = points.map(point => Number(point.price)).filter(price => Number.isFinite(price));
+
+  if (prices.length === 0) {
+    return { min: 0, max: 100 };
+  }
+
+  const minPrice = Math.min(...prices);
+  const maxPrice = Math.max(...prices);
+  const range = maxPrice - minPrice;
+  const padding = Math.max(range * 0.25, range < 2 ? 2 : 1);
+  const min = clampPercent(Math.floor((minPrice - padding) * 10) / 10);
+  const max = clampPercent(Math.ceil((maxPrice + padding) * 10) / 10);
+
+  if (max - min >= 4) {
+    return { min, max };
+  }
+
+  const midpoint = (minPrice + maxPrice) / 2;
+  return {
+    min: clampPercent(Math.floor((midpoint - 2) * 10) / 10),
+    max: clampPercent(Math.ceil((midpoint + 2) * 10) / 10),
+  };
+};
+
+const buildGroups = markets => {
+  const groups = new Map();
+
+  for (const market of markets) {
+    const key =
+      market.targetType === "event" ? `event:${market.targetSlug}` : `market:${market.id}`;
+    const title = market.targetType === "event" ? market.eventTitle : market.question;
+    const url =
+      market.targetType === "event"
+        ? `https://polymarket.com/event/${market.targetSlug}`
+        : market.url;
+
+    if (!groups.has(key)) {
+      groups.set(key, {
+        id: key,
+        title,
+        url,
+        series: [],
+      });
+    }
+
+    groups.get(key).series.push(market);
+  }
+
+  return [...groups.values()];
+};
+
+const normalizeHistory = history => {
+  if (!Array.isArray(history)) {
+    return [];
+  }
+
+  const normalized = history
+    .map(point => ({
+      timestamp: Number(point.timestamp),
+      price: Number(point.price),
+    }))
+    .filter(point => Number.isFinite(point.timestamp) && Number.isFinite(point.price))
+    .sort((left, right) => left.timestamp - right.timestamp);
+
+  const deduped = [];
+  for (const point of normalized) {
+    const last = deduped[deduped.length - 1];
+    if (last && last.timestamp === point.timestamp) {
+      last.price = point.price;
+    } else {
+      deduped.push(point);
+    }
+  }
+
+  return deduped;
+};
+
+const densifyHistory = history => {
+  if (!Array.isArray(history) || history.length === 0) {
+    return [];
+  }
+
+  if (history.length >= MIN_RENDER_POINTS) {
+    return history;
+  }
+
+  if (history.length === 1) {
+    const point = history[0];
+    return Array.from({ length: MIN_RENDER_POINTS }, (_, index) => ({
+      timestamp: point.timestamp - (MIN_RENDER_POINTS - 1 - index) * 60 * 60 * 1000,
+      price: point.price,
+    }));
+  }
+
+  const startTimestamp = history[0].timestamp;
+  const endTimestamp = history[history.length - 1].timestamp;
+  const totalDuration = Math.max(endTimestamp - startTimestamp, MIN_RENDER_POINTS - 1);
+  const points = [];
+
+  for (let index = 0; index < MIN_RENDER_POINTS; index += 1) {
+    const ratio = index / (MIN_RENDER_POINTS - 1);
+    const timestamp = startTimestamp + totalDuration * ratio;
+
+    let leftIndex = 0;
+    while (leftIndex < history.length - 1 && history[leftIndex + 1].timestamp < timestamp) {
+      leftIndex += 1;
+    }
+
+    const left = history[leftIndex];
+    const right = history[Math.min(leftIndex + 1, history.length - 1)];
+
+    if (!right || left.timestamp === right.timestamp) {
+      points.push({ timestamp, price: left.price });
+      continue;
+    }
+
+    const segmentRatio =
+      (timestamp - left.timestamp) / Math.max(right.timestamp - left.timestamp, 1);
+    const linearPrice = left.price + (right.price - left.price) * segmentRatio;
+    const wave = Math.sin(ratio * Math.PI * Math.max(history.length - 1, 1)) * 0.35;
+    const amplitude = Math.max(Math.abs(right.price - left.price), 0.6);
+    const price = Math.max(0, Math.min(100, linearPrice + wave * amplitude));
+
+    points.push({
+      timestamp,
+      price: Math.round(price * 10) / 10,
+    });
+  }
+
+  return points;
+};
+
+const buildSeriesPath = (history, scaleX, scaleY) =>
+  history
+    .map(
+      (point, index) =>
+        `${index === 0 ? "M" : "L"} ${scaleX(point.timestamp).toFixed(2)} ${scaleY(point.price).toFixed(2)}`,
+    )
+    .join(" ");
+
+const buildSeriesShadowPath = (history, scaleX, scaleY) =>
+  history
+    .map(
+      (point, index) =>
+        `${index === 0 ? "M" : "L"} ${scaleX(point.timestamp).toFixed(2)} ${(scaleY(point.price) + 1).toFixed(2)}`,
+    )
+    .join(" ");
+
+const getProbabilitySortValue = market =>
+  Number.isFinite(Number(market?.yesPercent)) ? Number(market.yesPercent) : -Infinity;
+
+const getVisibleSeries = markets =>
+  [...markets]
+    .sort((left, right) => getProbabilitySortValue(right) - getProbabilitySortValue(left))
+    .slice(0, MAX_VISIBLE_SERIES);
+
+const estimateTextWidth = text => String(text || "").length * 8.5;
+
+const truncateLabel = (label, maxWidth) => {
+  const normalizedLabel = String(label || "");
+  const maxCharacters = Math.max(8, Math.floor(maxWidth / 8.5));
+
+  if (normalizedLabel.length <= maxCharacters) {
+    return normalizedLabel;
+  }
+
+  return `${normalizedLabel.slice(0, Math.max(maxCharacters - 1, 1))}…`;
+};
+
+const getPointAtTimestamp = (history, timestamp) => {
+  if (!Array.isArray(history) || history.length === 0) {
+    return null;
+  }
+
+  if (timestamp <= history[0].timestamp) {
+    return history[0];
+  }
+
+  if (timestamp >= history[history.length - 1].timestamp) {
+    return history[history.length - 1];
+  }
+
+  for (let index = 0; index < history.length - 1; index += 1) {
+    const left = history[index];
+    const right = history[index + 1];
+
+    if (timestamp >= left.timestamp && timestamp <= right.timestamp) {
+      if (left.timestamp === right.timestamp) {
+        return left;
+      }
+
+      const ratio = (timestamp - left.timestamp) / (right.timestamp - left.timestamp);
+      return {
+        timestamp,
+        price: left.price + (right.price - left.price) * ratio,
+      };
+    }
+  }
+
+  return history[history.length - 1];
+};
+
+const splitHistoryByTimestamp = (history, timestamp) => {
+  if (!Array.isArray(history) || history.length === 0) {
+    return { active: [], muted: [] };
+  }
+
+  const hoverPoint = getPointAtTimestamp(history, timestamp);
+  const active = [];
+  const muted = [];
+
+  for (const point of history) {
+    if (point.timestamp <= timestamp) {
+      active.push(point);
+    } else {
+      muted.push(point);
+    }
+  }
+
+  if (active.length === 0) {
+    active.push(history[0]);
+  }
+
+  if (hoverPoint) {
+    const lastActive = active[active.length - 1];
+    if (!lastActive || lastActive.timestamp !== hoverPoint.timestamp) {
+      active.push(hoverPoint);
+    }
+
+    const firstMuted = muted[0];
+    if (firstMuted) {
+      if (firstMuted.timestamp !== hoverPoint.timestamp) {
+        muted.unshift(hoverPoint);
+      } else {
+        muted[0] = hoverPoint;
+      }
+    }
+  }
+
+  return { active, muted };
+};
+
+const adjustHoverLabels = (items, minY, maxY) => {
+  const sorted = [...items].sort((left, right) => left.labelY - right.labelY);
+
+  for (let index = 1; index < sorted.length; index += 1) {
+    const previous = sorted[index - 1];
+    const current = sorted[index];
+    if (current.labelY - previous.labelY < HOVER_LABEL_HEIGHT + HOVER_LABEL_GAP) {
+      current.labelY = previous.labelY + HOVER_LABEL_HEIGHT + HOVER_LABEL_GAP;
+    }
+  }
+
+  const overflow = sorted[sorted.length - 1]?.labelY - maxY;
+  if (overflow > 0) {
+    for (let index = sorted.length - 1; index >= 0; index -= 1) {
+      sorted[index].labelY -= overflow;
+    }
+  }
+
+  const underflow = minY - (sorted[0]?.labelY ?? minY);
+  if (underflow > 0) {
+    for (let index = 0; index < sorted.length; index += 1) {
+      sorted[index].labelY += underflow;
+    }
+  }
+
+  return sorted;
+};
+
+const JsonLd = ({ title, description, url }) => {
+  const payload = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: title,
+    description,
+    url,
+    publisher: {
+      "@type": "Organization",
+      name: "Polymarket",
+      url: "https://polymarket.com",
+    },
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(payload),
+      }}
+    />
+  );
+};
+
+function EventEmbedFigure({ group }) {
+  const containerRef = useRef(null);
+  const [width, setWidth] = useState(0);
+  const [hoverX, setHoverX] = useState(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return undefined;
+    }
+
+    const updateSize = () => {
+      const nextWidth = container.getBoundingClientRect().width;
+      setWidth(nextWidth);
+    };
+
+    updateSize();
+
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", updateSize);
+      return () => window.removeEventListener("resize", updateSize);
+    }
+
+    const resizeObserver = new ResizeObserver(updateSize);
+    resizeObserver.observe(container);
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  const visibleSeries = useMemo(
+    () =>
+      getVisibleSeries(group.series).map((market, index) => ({
+        ...market,
+        color: COLORS[index % COLORS.length],
+        shortLabel: market.seriesLabel || market.label || market.question,
+        history: densifyHistory(normalizeHistory(market.history)),
+      })),
+    [group.series],
+  );
+
+  const geometry = useMemo(() => {
+    if (width <= 0 || visibleSeries.length === 0) {
+      return null;
+    }
+
+    const allPoints = visibleSeries.flatMap(item => item.history);
+    if (allPoints.length === 0) {
+      return null;
+    }
+
+    const minTimestamp = Math.min(...allPoints.map(point => point.timestamp));
+    const maxTimestamp = Math.max(...allPoints.map(point => point.timestamp));
+    const plotWidth = Math.max(width - LEFT_GUTTER - RIGHT_GUTTER, 160);
+    const plotHeight = CHART_HEIGHT - PLOT_TOP - PLOT_BOTTOM;
+    const xRange = Math.max(maxTimestamp - minTimestamp, 1);
+
+    const scaleX = timestamp => LEFT_GUTTER + ((timestamp - minTimestamp) / xRange) * plotWidth;
+    const yDomain = buildPriceDomain(allPoints);
+    const yRange = Math.max(yDomain.max - yDomain.min, 1);
+    const scaleY = price =>
+      PLOT_TOP + (1 - (clampPercent(price) - yDomain.min) / yRange) * plotHeight;
+
+    const dayTicks = [];
+    const dayCount = Math.min(6, Math.max(3, Math.floor(xRange / (24 * 60 * 60 * 1000)) + 1));
+    for (let index = 0; index < dayCount; index += 1) {
+      const ratio = dayCount === 1 ? 0 : index / (dayCount - 1);
+      const timestamp = minTimestamp + xRange * ratio;
+      dayTicks.push({
+        x: scaleX(timestamp),
+        label: formatTimeLabel(timestamp),
+      });
+    }
+
+    const endpoints = visibleSeries
+      .map(item => {
+        const point =
+          hoverX === null
+            ? item.history[item.history.length - 1]
+            : getPointAtTimestamp(
+                item.history,
+                minTimestamp + ((hoverX - LEFT_GUTTER) / Math.max(plotWidth, 1)) * xRange,
+              );
+
+        if (!point) {
+          return null;
+        }
+
+        return {
+          id: item.id,
+          color: item.color,
+          label: item.shortLabel,
+          percent: formatPercent(point.price),
+          x: scaleX(point.timestamp),
+          y: scaleY(point.price),
+          labelY: scaleY(point.price),
+        };
+      })
+      .filter(Boolean);
+
+    const adjustedEndpoints = adjustHoverLabels(
+      endpoints.map(item => ({ ...item })),
+      PLOT_TOP + 8,
+      CHART_HEIGHT - PLOT_BOTTOM - HOVER_LABEL_HEIGHT - 8,
+    );
+
+    return {
+      dayTicks,
+      hoverTimestamp:
+        hoverX === null
+          ? null
+          : minTimestamp + ((hoverX - LEFT_GUTTER) / Math.max(plotWidth, 1)) * xRange,
+      plotEndX: LEFT_GUTTER + plotWidth,
+      plotWidth,
+      scaleX,
+      scaleY,
+      adjustedEndpoints,
+    };
+  }, [hoverX, visibleSeries, width]);
+
+  const description = visibleSeries
+    .map(item => `${item.shortLabel} ${formatPercent(item.yesPercent)}`)
+    .join(" · ");
+
+  const hoverLabel = geometry?.hoverTimestamp
+    ? new Date(geometry.hoverTimestamp).toLocaleString("zh-CN", {
+        month: "numeric",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      })
+    : null;
+  const chartTitle = truncateLabel(
+    group.title,
+    Math.max(96, Math.max(width, 320) - LEFT_GUTTER - RIGHT_GUTTER - CHART_TITLE_RESERVED_WIDTH),
+  );
+
+  return (
+    <figure
+      ref={containerRef}
+      className="relative m-0 w-full max-w-[920px] overflow-hidden border border-[var(--pm-border)] bg-[var(--pm-bg)] p-5 text-[var(--pm-title)] [--pm-axis:#94A3B8] [--pm-bg:#FFFFFF] [--pm-border:#E2E8F0] [--pm-hover-line:#CBD5E1] [--pm-hover-line-idle:#E2E8F0] [--pm-muted:#64748B] [--pm-muted-line:#94A3B8] [--pm-shadow-path:rgba(15,23,42,0.12)] [--pm-title:#0F172A] [--pm-tooltip-bg:#FFFFFF] [--pm-tooltip-border:#CBD5E1] [--pm-tooltip-text:#0F172A] dark:[--pm-axis:#334253] dark:[--pm-bg:#18181B] dark:[--pm-border:#151A21] dark:[--pm-hover-line:#334155] dark:[--pm-hover-line-idle:#151A20] dark:[--pm-muted:#91A0B4] dark:[--pm-muted-line:#48515D] dark:[--pm-shadow-path:rgba(0,0,0,0.18)] dark:[--pm-title:#F3F5F7] dark:[--pm-tooltip-bg:#0A0D11] dark:[--pm-tooltip-border:#293240] dark:[--pm-tooltip-text:#F3F5F7]"
+      aria-label={`prediction market: ${group.title}`}
+      itemScope
+      itemType="https://schema.org/WebPage"
+    >
+      <JsonLd
+        title={group.title}
+        description={`Prediction market: ${description} on Polymarket.`}
+        url={group.url}
+      />
+
+      {geometry ? (
+        <svg
+          viewBox={`0 0 ${Math.max(width, 320)} ${CHART_HEIGHT}`}
+          className="block h-[420px] w-full"
+          onMouseLeave={() => setHoverX(null)}
+          onMouseMove={event => {
+            const rect = event.currentTarget.getBoundingClientRect();
+            const nextX = ((event.clientX - rect.left) / rect.width) * Math.max(width, 320);
+            const boundedX = Math.max(LEFT_GUTTER, Math.min(geometry.plotEndX, nextX));
+            setHoverX(boundedX);
+          }}
+        >
+          <text
+            x={LEFT_GUTTER}
+            y={CHART_TITLE_Y}
+            fill="var(--pm-title)"
+            fontSize="26"
+            fontWeight="700"
+          >
+            <title>{group.title}</title>
+            {chartTitle}
+          </text>
+
+          <foreignObject x={LEFT_GUTTER} y={CHART_LEGEND_Y} width={geometry.plotWidth} height="34">
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[13px] leading-none text-[var(--pm-muted)]">
+              {visibleSeries.map(item => (
+                <div key={item.id} className="flex items-center gap-2">
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-full shadow-[0_0_0_2px_rgba(255,255,255,0.02)]"
+                    style={{ backgroundColor: item.color }}
+                  />
+                  <span>
+                    {item.shortLabel}{" "}
+                    <span className="font-semibold text-[var(--pm-title)]">
+                      {formatPercent(item.yesPercent)}
+                    </span>
+                  </span>
+                </div>
+              ))}
+            </div>
+          </foreignObject>
+
+          <line
+            x1={hoverX ?? geometry.plotEndX}
+            x2={hoverX ?? geometry.plotEndX}
+            y1={PLOT_TOP - 6}
+            y2={CHART_HEIGHT - PLOT_BOTTOM + 4}
+            stroke={hoverX === null ? "var(--pm-hover-line-idle)" : "var(--pm-hover-line)"}
+            strokeWidth="1.5"
+          />
+
+          {visibleSeries.map(item => {
+            const split =
+              hoverX === null || geometry.hoverTimestamp === null
+                ? { active: item.history, muted: [] }
+                : splitHistoryByTimestamp(item.history, geometry.hoverTimestamp);
+            const activePath = buildSeriesPath(split.active, geometry.scaleX, geometry.scaleY);
+            const activeShadowPath = buildSeriesShadowPath(
+              split.active,
+              geometry.scaleX,
+              geometry.scaleY,
+            );
+            const mutedPath = buildSeriesPath(split.muted, geometry.scaleX, geometry.scaleY);
+
+            return (
+              <g key={item.id}>
+                <path
+                  d={activeShadowPath}
+                  fill="none"
+                  stroke="var(--pm-shadow-path)"
+                  strokeWidth="4"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d={activePath}
+                  fill="none"
+                  stroke={item.color}
+                  strokeWidth="3"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                {mutedPath && (
+                  <path
+                    d={mutedPath}
+                    fill="none"
+                    stroke="var(--pm-muted-line)"
+                    strokeWidth="3"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    opacity="0.75"
+                  />
+                )}
+              </g>
+            );
+          })}
+
+          {geometry.adjustedEndpoints.map(item => (
+            <g key={item.id}>
+              <circle cx={item.x} cy={item.y} r="6" fill={item.color} />
+              {hoverX !== null && (
+                <circle cx={item.x} cy={item.y} r="11" fill={item.color} opacity="0.16" />
+              )}
+              {hoverX !== null &&
+                (() => {
+                  const percentWidth = estimateTextWidth(item.percent);
+                  const labelMaxWidth = Math.max(
+                    72,
+                    Math.min(
+                      HOVER_LABEL_MAX_WIDTH - percentWidth - HOVER_LABEL_PADDING_X * 2 - 10,
+                      Math.max(width, 320) - LEFT_GUTTER - RIGHT_GUTTER - percentWidth - 64,
+                    ),
+                  );
+                  const visibleLabel = truncateLabel(item.label, labelMaxWidth);
+                  const labelWidth = Math.min(
+                    HOVER_LABEL_MAX_WIDTH,
+                    Math.max(
+                      126,
+                      estimateTextWidth(visibleLabel) +
+                        percentWidth +
+                        HOVER_LABEL_PADDING_X * 2 +
+                        12,
+                    ),
+                  );
+                  const chartRight = Math.max(width, 320) - 8;
+                  const preferRight = item.x + 16 + labelWidth <= chartRight;
+                  const labelX = preferRight
+                    ? item.x + 16
+                    : Math.max(LEFT_GUTTER, item.x - labelWidth - 16);
+
+                  return (
+                    <g>
+                      <rect
+                        x={labelX}
+                        y={item.labelY - HOVER_LABEL_HEIGHT / 2}
+                        rx="10"
+                        ry="10"
+                        width={labelWidth}
+                        height={HOVER_LABEL_HEIGHT}
+                        fill="var(--pm-tooltip-bg)"
+                        stroke="var(--pm-tooltip-border)"
+                      />
+                      <rect
+                        x={labelX + 9}
+                        y={item.labelY - 11}
+                        width="6"
+                        height="22"
+                        rx="3"
+                        fill={item.color}
+                      />
+                      <text
+                        x={labelX + HOVER_LABEL_PADDING_X + 8}
+                        y={item.labelY + 1}
+                        fill="var(--pm-tooltip-text)"
+                        fontSize="15"
+                        fontWeight="600"
+                        dominantBaseline="middle"
+                      >
+                        <title>{item.label}</title>
+                        {visibleLabel}
+                      </text>
+                      <text
+                        x={labelX + labelWidth - HOVER_LABEL_PADDING_X}
+                        y={item.labelY + 1}
+                        fill="var(--pm-muted)"
+                        fontSize="15"
+                        fontWeight="600"
+                        dominantBaseline="middle"
+                        textAnchor="end"
+                      >
+                        {item.percent}
+                      </text>
+                    </g>
+                  );
+                })()}
+            </g>
+          ))}
+
+          {hoverLabel && (
+            <text
+              x={Math.max(width, 320) - RIGHT_GUTTER}
+              y={PLOT_TOP - 16}
+              fill="var(--pm-muted)"
+              fontSize="14"
+              textAnchor="end"
+            >
+              {hoverLabel}
+            </text>
+          )}
+
+          {geometry.dayTicks.map(tick => (
+            <text
+              key={`${tick.x}-${tick.label}`}
+              x={tick.x}
+              y={CHART_HEIGHT - 18}
+              fill="var(--pm-axis)"
+              fontSize="14"
+              textAnchor="middle"
+            >
+              {tick.label}
+            </text>
+          ))}
+        </svg>
+      ) : (
+        <div className="flex h-[420px] items-center justify-center text-sm text-[var(--pm-muted)]">
+          暂无走势图数据
+        </div>
+      )}
+
+      <figcaption className="sr-only">
+        <strong>{group.title}</strong>
+        <br />
+        {description}
+        <br />
+        <a href={group.url}>View full market &amp; trade on Polymarket</a>
+      </figcaption>
+    </figure>
+  );
+}
+
+export default function PolymarketProbabilityBoard({ markets }) {
+  const groups = useMemo(() => buildGroups(markets || []), [markets]);
+
+  if (groups.length === 0) {
+    return (
+      <div className="rounded-3xl border border-zinc-200 bg-zinc-50 px-5 py-8 text-center text-sm text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900/70 dark:text-zinc-400">
+        暂时没有可展示的事件概率数据。
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      {groups.map(group => (
+        <EventEmbedFigure key={group.id} group={group} />
+      ))}
+    </div>
+  );
+}

--- a/lib/polymarket-data-fetcher.js
+++ b/lib/polymarket-data-fetcher.js
@@ -307,12 +307,15 @@ export const fetchPolymarketProbabilityBoard = async () => {
     return empty;
   }
 
-  const targetResults = await Promise.all(
+  const settledTargetResults = await Promise.allSettled(
     watchlist.map(async target => ({
       target,
       markets: await fetchTargetMarkets(target),
     })),
   );
+  const targetResults = settledTargetResults
+    .filter(result => result.status === "fulfilled")
+    .map(result => result.value);
 
   const markets = targetResults.flatMap(item => item.markets).map(market => ({ ...market }));
   const marketsWithHistory = await Promise.all(

--- a/lib/polymarket-data-fetcher.js
+++ b/lib/polymarket-data-fetcher.js
@@ -1,0 +1,346 @@
+import cache from "./cache.js";
+import polymarketWatchlist from "./polymarket-watchlist.json";
+
+const POLYMARKET_EVENTS_API =
+  process.env.POLYMARKET_EVENTS_API || "https://gamma-api.polymarket.com/events";
+const POLYMARKET_MARKETS_API =
+  process.env.POLYMARKET_MARKETS_API || "https://gamma-api.polymarket.com/markets";
+const POLYMARKET_HISTORY_API =
+  process.env.POLYMARKET_HISTORY_API || "https://clob.polymarket.com/prices-history";
+const POLYMARKET_PROXY_URL = process.env.NEXT_PUBLIC_PROXY_URL || "";
+const POLYMARKET_CACHE_KEY = "polymarket_probability_board";
+const POLYMARKET_CACHE_TTL = 60;
+const REQUEST_TIMEOUT_MS = 6000;
+const HISTORY_WINDOW_DAYS = 14;
+
+const emptyResult = () => ({
+  markets: [],
+  timestamp: Date.now(),
+});
+
+const parseJsonArray = value => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value !== "string" || value.trim() === "") {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+const parseNumber = value => {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const parseTokenIds = value => {
+  const parsed = parseJsonArray(value);
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+
+  return parsed.filter(item => typeof item === "string" && item.trim() !== "");
+};
+
+const clampProbability = value => Math.min(1, Math.max(0, value));
+
+const toPercent = value => Math.round(value * 1000) / 10;
+
+const deriveSeriesLabel = market => {
+  if (typeof market.groupItemTitle === "string" && market.groupItemTitle.trim() !== "") {
+    return market.groupItemTitle.trim();
+  }
+
+  if (typeof market.question !== "string") {
+    return "";
+  }
+
+  const match = market.question.match(/^Will\s+(.+?)\s+have\b/i);
+  return match?.[1]?.trim() || "";
+};
+
+const buildMarketUrl = (event, market) => {
+  const slug = market.slug || event.slug;
+  return slug ? `https://polymarket.com/event/${slug}` : "https://polymarket.com";
+};
+
+const normalizeTarget = target => {
+  if (!target || typeof target !== "object") {
+    return null;
+  }
+
+  const type = target.type === "event" ? "event" : "market";
+  const slug = typeof target.slug === "string" ? target.slug.trim() : "";
+
+  if (!slug) {
+    return null;
+  }
+
+  return {
+    type,
+    slug,
+    label: typeof target.label === "string" ? target.label.trim() : "",
+  };
+};
+
+const getWatchlist = () =>
+  Array.isArray(polymarketWatchlist)
+    ? polymarketWatchlist.map(normalizeTarget).filter(Boolean)
+    : [];
+
+const buildPolymarketRequestUrl = url => {
+  if (!POLYMARKET_PROXY_URL) {
+    return url;
+  }
+
+  return `${POLYMARKET_PROXY_URL}${url.replace(/^https?:\/\//u, "")}`;
+};
+
+const fetchJson = async url => {
+  const response = await fetch(buildPolymarketRequestUrl(url), {
+    headers: {
+      accept: "application/json",
+    },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Polymarket API request failed with status ${response.status}`);
+  }
+
+  return await response.json();
+};
+
+const buildFallbackHistory = market => {
+  const currentPrice = market.yesPercent;
+  const oneDayDelta = toPercent(parseNumber(market.oneDayPriceChange) ?? 0);
+  const startPrice = Math.min(100, Math.max(0, currentPrice - oneDayDelta));
+  const now = Date.now();
+  const steps = 24;
+
+  return Array.from({ length: steps }, (_, index) => {
+    const progress = index / Math.max(steps - 1, 1);
+    const price = startPrice + (currentPrice - startPrice) * progress;
+
+    return {
+      timestamp: now - (steps - 1 - index) * 60 * 60 * 1000,
+      price: Math.round(price * 10) / 10,
+    };
+  });
+};
+
+const normalizeMarket = (event, market) => {
+  if (!market?.active || market.closed || market.archived) {
+    return null;
+  }
+
+  const outcomes = parseJsonArray(market.outcomes);
+  const outcomePrices = parseJsonArray(market.outcomePrices);
+
+  if (
+    !Array.isArray(outcomes) ||
+    !Array.isArray(outcomePrices) ||
+    outcomes.length !== outcomePrices.length
+  ) {
+    return null;
+  }
+
+  const normalizedOutcomes = outcomes.map(outcome =>
+    typeof outcome === "string" ? outcome.trim().toLowerCase() : "",
+  );
+  const yesIndex = normalizedOutcomes.findIndex(outcome => outcome === "yes");
+  const noIndex = normalizedOutcomes.findIndex(outcome => outcome === "no");
+
+  if (yesIndex === -1 || noIndex === -1) {
+    return null;
+  }
+
+  const yesProbability = parseNumber(outcomePrices[yesIndex]);
+  const noProbability = parseNumber(outcomePrices[noIndex]);
+  const clobTokenIds = parseTokenIds(market.clobTokenIds);
+
+  if (yesProbability === null || noProbability === null) {
+    return null;
+  }
+
+  const probability = clampProbability(yesProbability);
+  const endDate = market.endDate || event.endDate || null;
+  const endTimestamp = endDate ? Date.parse(endDate) : null;
+
+  if (!market.question || endTimestamp === null || Number.isNaN(endTimestamp)) {
+    return null;
+  }
+
+  return {
+    id: String(market.id),
+    eventTitle: event.title || market.question,
+    question: market.question,
+    seriesLabel: deriveSeriesLabel(market),
+    url: buildMarketUrl(event, market),
+    yesClobTokenId: clobTokenIds[yesIndex] || "",
+    yesPercent: toPercent(probability),
+    oneDayPriceChange: parseNumber(market.oneDayPriceChange),
+  };
+};
+
+const toEventShapeFromMarket = market => {
+  const event = Array.isArray(market.events) ? market.events[0] : null;
+
+  if (!event) {
+    return null;
+  }
+
+  return {
+    id: event.id,
+    slug: event.slug,
+    title: event.title,
+    endDate: event.endDate,
+    markets: [market],
+  };
+};
+
+const fetchEventBySlug = async slug => {
+  const params = new URLSearchParams({ slug });
+  const events = await fetchJson(`${POLYMARKET_EVENTS_API}?${params.toString()}`);
+  return Array.isArray(events) ? events[0] || null : null;
+};
+
+const fetchMarketBySlug = async slug => {
+  const params = new URLSearchParams({ slug });
+  const markets = await fetchJson(`${POLYMARKET_MARKETS_API}?${params.toString()}`);
+  return Array.isArray(markets) ? markets[0] || null : null;
+};
+
+const fetchMarketHistory = async clobTokenId => {
+  if (!clobTokenId) {
+    return [];
+  }
+
+  const endTimestamp = Math.floor(Date.now() / 1000);
+  const startTimestamp = endTimestamp - HISTORY_WINDOW_DAYS * 24 * 60 * 60;
+  const params = new URLSearchParams({
+    market: String(clobTokenId),
+    startTs: String(startTimestamp),
+    endTs: String(endTimestamp),
+    fidelity: "60",
+  });
+
+  try {
+    const payload = await fetchJson(`${POLYMARKET_HISTORY_API}?${params.toString()}`);
+
+    if (!payload || !Array.isArray(payload.history)) {
+      return [];
+    }
+
+    return payload.history
+      .map(point => ({
+        timestamp: Number(point.t) * 1000,
+        price: toPercent(parseNumber(point.p) ?? 0),
+      }))
+      .filter(point => Number.isFinite(point.timestamp) && Number.isFinite(point.price));
+  } catch (error) {
+    console.error(`Error fetching polymarket history for token ${clobTokenId}:`, error);
+    return [];
+  }
+};
+
+const fetchTargetMarkets = async target => {
+  if (target.type === "event") {
+    const event = await fetchEventBySlug(target.slug);
+
+    if (!event || !Array.isArray(event.markets)) {
+      return [];
+    }
+
+    return event.markets
+      .map(market => normalizeMarket(event, market))
+      .filter(Boolean)
+      .map(market => ({
+        ...market,
+        question: target.label || market.question,
+        targetType: target.type,
+        targetSlug: target.slug,
+      }));
+  }
+
+  const market = await fetchMarketBySlug(target.slug);
+  const event = market ? toEventShapeFromMarket(market) : null;
+
+  if (!market || !event) {
+    return [];
+  }
+
+  const normalizedMarket = normalizeMarket(event, market);
+
+  if (!normalizedMarket) {
+    return [];
+  }
+
+  return [
+    {
+      ...normalizedMarket,
+      question: target.label || normalizedMarket.question,
+      targetType: target.type,
+      targetSlug: target.slug,
+    },
+  ];
+};
+
+export const fetchPolymarketProbabilityBoard = async () => {
+  const cached = cache.get(POLYMARKET_CACHE_KEY);
+  if (cached) {
+    return cached;
+  }
+
+  const watchlist = getWatchlist();
+
+  if (watchlist.length === 0) {
+    const empty = emptyResult();
+    cache.set(POLYMARKET_CACHE_KEY, empty, POLYMARKET_CACHE_TTL);
+    return empty;
+  }
+
+  const targetResults = await Promise.all(
+    watchlist.map(async target => ({
+      target,
+      markets: await fetchTargetMarkets(target),
+    })),
+  );
+
+  const markets = targetResults.flatMap(item => item.markets).map(market => ({ ...market }));
+  const marketsWithHistory = await Promise.all(
+    markets.map(async market => {
+      const history = await fetchMarketHistory(market.yesClobTokenId);
+
+      return {
+        id: market.id,
+        eventTitle: market.eventTitle,
+        question: market.question,
+        seriesLabel: market.seriesLabel,
+        url: market.url,
+        yesPercent: market.yesPercent,
+        targetType: market.targetType,
+        targetSlug: market.targetSlug,
+        history: history.length > 0 ? history : buildFallbackHistory(market),
+      };
+    }),
+  );
+
+  const result = {
+    markets: marketsWithHistory,
+    timestamp: Date.now(),
+  };
+
+  cache.set(POLYMARKET_CACHE_KEY, result, POLYMARKET_CACHE_TTL);
+
+  return result;
+};
+
+export const getEmptyPolymarketProbabilityBoard = emptyResult;

--- a/lib/polymarket-watchlist.json
+++ b/lib/polymarket-watchlist.json
@@ -13,6 +13,10 @@
   },
   {
     "type": "event",
+    "slug": "what-will-gold-gc-hit-by-end-of-december"
+  },
+  {
+    "type": "event",
     "slug": "ai-bubble-burst-by"
   }
 ]

--- a/lib/polymarket-watchlist.json
+++ b/lib/polymarket-watchlist.json
@@ -1,0 +1,18 @@
+[
+  {
+    "type": "event",
+    "slug": "best-chinese-ai-company-end-of-june"
+  },
+  {
+    "type": "event",
+    "slug": "peoples-bank-of-china-rate-change-in-june"
+  },
+  {
+    "type": "event",
+    "slug": "world-cup-winner"
+  },
+  {
+    "type": "event",
+    "slug": "ai-bubble-burst-by"
+  }
+]

--- a/lib/vix-data-fetcher.js
+++ b/lib/vix-data-fetcher.js
@@ -3,6 +3,8 @@
 
 import cache from "./cache.js";
 
+const REQUEST_TIMEOUT_MS = 8000;
+
 const emptyVixData = dataType => ({
   data: [],
   timestamp: Date.now(),
@@ -24,7 +26,7 @@ export const fetchDailyVixData = async () => {
   }
 
   const apiResponse = await fetch(apiUrl, {
-    signal: AbortSignal.timeout(30000),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
 
   if (!apiResponse.ok) {
@@ -93,7 +95,7 @@ export const fetchMinuteVixData = async () => {
   }
 
   const apiResponse = await fetch(apiUrl, {
-    signal: AbortSignal.timeout(30000),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
 
   if (!apiResponse.ok) {

--- a/pages/api/polymarket-data.js
+++ b/pages/api/polymarket-data.js
@@ -1,0 +1,24 @@
+import {
+  fetchPolymarketProbabilityBoard,
+  getEmptyPolymarketProbabilityBoard,
+} from "../../lib/polymarket-data-fetcher";
+
+export default async function handler(req, res) {
+  try {
+    const result = await fetchPolymarketProbabilityBoard();
+    res.status(200).json(result);
+  } catch (error) {
+    console.error("Error fetching polymarket data:", error);
+    res.status(200).json({
+      ...getEmptyPolymarketProbabilityBoard(),
+      error: "Failed to fetch Polymarket data",
+      message: error.message,
+    });
+  }
+}
+
+export const config = {
+  api: {
+    responseLimit: "4mb",
+  },
+};

--- a/pages/api/polymarket-data.js
+++ b/pages/api/polymarket-data.js
@@ -9,7 +9,7 @@ export default async function handler(req, res) {
     res.status(200).json(result);
   } catch (error) {
     console.error("Error fetching polymarket data:", error);
-    res.status(200).json({
+    res.status(502).json({
       ...getEmptyPolymarketProbabilityBoard(),
       error: "Failed to fetch Polymarket data",
       message: error.message,

--- a/pages/blog/polymarket.js
+++ b/pages/blog/polymarket.js
@@ -10,15 +10,16 @@ import {
 const REFRESH_INTERVAL = 60000;
 const FETCH_TIMEOUT_MS = 8000;
 
-const createTitle = () => "预测市场";
+const createTitle = () => "Polymarket";
 
 export const blogProps = {
   author: cfg.authorName,
-  title: "预测市场",
-  description: "基于 Polymarket 活跃市场的事件发生概率看板",
+  title: "Polymarket",
+  description: "基于 Polymarket 二元期权市场的事件发生概率看板",
   date: "2026-06-19",
   locale: "zh",
   visible: true,
+  tags: "market, trade",
   preview: {
     type: "chart",
     source: "polymarket",
@@ -104,17 +105,17 @@ export default function PolymarketPage({ serverSnapshot }) {
   const markets = snapshot?.markets || [];
 
   return (
-    <Blog {...blogProps} title={createTitle()} noReply noMeta>
-      <div className="my-2 max-w-4xl m-auto">
-        <PolymarketProbabilityBoard markets={markets} />
-      </div>
+    <Blog {...blogProps} title={createTitle()} noReply>
       <p>
         Polymarket
-        的核心是可交易的二元事件合约。它越来越值得关注，不是因为把「下注」搬上链，而是因为高关注事件上的流动性、订单深度和连续报价，正在把分散的信息压成一条能实时更新的概率曲线；这使它更像信息市场，而不只是娱乐盘口。与传统赌博也不一样，后者通常是庄家定赔率、玩家承担抽水，前者更像连续交易市场，你面对的是其他交易者和不断进入的新信息，价格既能交易，也能被外部世界拿来做判断。对凯利公式来说，这类市场尤其有用，因为它直接给出了市场价格{" "}
+        的核心是可交易的二元事件合约。它越来越值得关注，不光是因为把「下注」搬上区块链，而是因为高关注事件上的流动性、订单深度和连续报价，正在把分散的信息压成一条能实时更新的概率曲线；这使它更像信息市场，而不只是娱乐盘口。与传统盘口不同，后者通常是庄家定赔率、玩家承担抽水，前者更像连续交易市场，你面对的是其他交易者和不断进入的新信息，价格既能交易，也能被外部世界拿来做判断。对凯利公式来说，这类市场尤其有用，因为它直接给出了市场价格{" "}
         <code>q</code>；如果你自己的主观概率是 <code>p</code>，就可以据此判断是否存在优势，并用{" "}
         <code>f* = (p - q) / (1 - q)</code>{" "}
         这样的二元凯利形式来约束仓位。实务上通常应采用半凯利或更低仓位，因为你的概率估计误差、手续费、滑点和相关性，往往比公式本身更重要。
       </p>
+      <div className="my-2 max-w-4xl m-auto">
+        <PolymarketProbabilityBoard markets={markets} />
+      </div>
     </Blog>
   );
 }

--- a/pages/blog/polymarket.js
+++ b/pages/blog/polymarket.js
@@ -8,6 +8,7 @@ import {
 } from "../../lib/polymarket-data-fetcher";
 
 const REFRESH_INTERVAL = 60000;
+const FETCH_TIMEOUT_MS = 8000;
 
 const createTitle = () => "预测市场";
 
@@ -61,9 +62,13 @@ export default function PolymarketPage({ serverSnapshot }) {
       }
 
       inFlight = true;
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
       try {
-        const response = await fetch("/api/polymarket-data");
+        const response = await fetch("/api/polymarket-data", {
+          signal: controller.signal,
+        });
 
         if (!response.ok) {
           throw new Error(`Failed to fetch Polymarket data: ${response.status}`);
@@ -74,6 +79,7 @@ export default function PolymarketPage({ serverSnapshot }) {
       } catch (error) {
         console.error("Error updating polymarket snapshot:", error);
       } finally {
+        clearTimeout(timeoutId);
         inFlight = false;
       }
     };

--- a/pages/blog/polymarket.js
+++ b/pages/blog/polymarket.js
@@ -1,0 +1,114 @@
+import { useEffect, useState } from "react";
+import Blog from "../../components/blog";
+import PolymarketProbabilityBoard from "../../components/polymarket-probability-board";
+import cfg from "../../lib/config.mjs";
+import {
+  fetchPolymarketProbabilityBoard,
+  getEmptyPolymarketProbabilityBoard,
+} from "../../lib/polymarket-data-fetcher";
+
+const REFRESH_INTERVAL = 60000;
+
+const createTitle = () => "预测市场";
+
+export const blogProps = {
+  author: cfg.authorName,
+  title: "预测市场",
+  description: "基于 Polymarket 活跃市场的事件发生概率看板",
+  date: "2026-06-19",
+  locale: "zh",
+  visible: true,
+  preview: {
+    type: "chart",
+    source: "polymarket",
+    title: "Polymarket 事件概率",
+    dataType: "live",
+  },
+};
+
+export const getStaticProps = async () => {
+  try {
+    const snapshot = await fetchPolymarketProbabilityBoard();
+
+    return {
+      props: {
+        serverSnapshot: snapshot,
+      },
+      revalidate: 60,
+    };
+  } catch (error) {
+    console.error("Error fetching initial polymarket data:", error);
+
+    return {
+      props: {
+        serverSnapshot: getEmptyPolymarketProbabilityBoard(),
+      },
+      revalidate: 60,
+    };
+  }
+};
+
+export default function PolymarketPage({ serverSnapshot }) {
+  const [snapshot, setSnapshot] = useState(serverSnapshot);
+
+  useEffect(() => {
+    let intervalId;
+    let inFlight = false;
+
+    const update = async () => {
+      if (inFlight || document.hidden) {
+        return;
+      }
+
+      inFlight = true;
+
+      try {
+        const response = await fetch("/api/polymarket-data");
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch Polymarket data: ${response.status}`);
+        }
+
+        const nextSnapshot = await response.json();
+        setSnapshot(nextSnapshot);
+      } catch (error) {
+        console.error("Error updating polymarket snapshot:", error);
+      } finally {
+        inFlight = false;
+      }
+    };
+
+    update();
+    intervalId = setInterval(update, REFRESH_INTERVAL);
+
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        update();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, []);
+
+  const markets = snapshot?.markets || [];
+
+  return (
+    <Blog {...blogProps} title={createTitle()} noReply noMeta>
+      <div className="my-2 max-w-4xl m-auto">
+        <PolymarketProbabilityBoard markets={markets} />
+      </div>
+      <p>
+        Polymarket
+        的核心是可交易的二元事件合约。它越来越值得关注，不是因为把「下注」搬上链，而是因为高关注事件上的流动性、订单深度和连续报价，正在把分散的信息压成一条能实时更新的概率曲线；这使它更像信息市场，而不只是娱乐盘口。与传统赌博也不一样，后者通常是庄家定赔率、玩家承担抽水，前者更像连续交易市场，你面对的是其他交易者和不断进入的新信息，价格既能交易，也能被外部世界拿来做判断。对凯利公式来说，这类市场尤其有用，因为它直接给出了市场价格{" "}
+        <code>q</code>；如果你自己的主观概率是 <code>p</code>，就可以据此判断是否存在优势，并用{" "}
+        <code>f* = (p - q) / (1 - q)</code>{" "}
+        这样的二元凯利形式来约束仓位。实务上通常应采用半凯利或更低仓位，因为你的概率估计误差、手续费、滑点和相关性，往往比公式本身更重要。
+      </p>
+    </Blog>
+  );
+}

--- a/pages/blog/vix.js
+++ b/pages/blog/vix.js
@@ -18,6 +18,7 @@ export const blogProps = {
   date: "2025-09-28",
   locale: "zh",
   visible: true,
+  tags: "market, trade",
   preview: {
     type: "chart",
     source: "vix",
@@ -191,7 +192,7 @@ export default function Vix(props) {
   }, []);
 
   return (
-    <Blog {...blogProps} title={`${blogProps.title}: ${current || "加载中..."}`} noReply noMeta>
+    <Blog {...blogProps} title={`${blogProps.title}: ${current || "加载中..."}`} noReply>
       <div className="h-72 md:h-96 w-full text-center my-10">
         <div className="mb-2">
           沪深 300 股指期权隐含波动率 当前: {current !== null ? current.toFixed(2) : "加载中..."}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 Polymarket 概率看板与博客页面：按事件/市场分组交互式折线图，支持悬浮查看端点与时间；无数据时显示“暂无走势图数据/暂时没有可展示的事件概率数据”；页面支持每 60 秒自动刷新。
  * 新增 Polymarket 数据接口，失败时返回兜底结果。
* **体验优化**
  * 页面不可见时暂停轮询，恢复可见后立即更新；请求超时自动中止。
  * 调整博客底部元信息展示规则；VIX 页面补充标签。
* **性能优化**
  * 统一 VIX 数据请求超时配置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->